### PR TITLE
1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rogue-maze
+# rogue-maze 1.0.5-beta
 
 A simple video game I made with Godot 3 to avoid having to print the mazes generated with [mazes-scala](https://github.com/jGonzalezFernandez/mazes-scala). It should give you about 20 minutes of fun... if you like mazes.
 
@@ -18,7 +18,7 @@ On the bright side, there are many possible workflows, so it's easy to find one 
 
 **Textures** (slightly modified):
 
-https://www.kenney.nl/assets/bit-pack (CC0 1.0): most of the characters, inventory items...
+https://www.kenney.nl/assets/1-bit-pack (CC0 1.0): most of the characters, inventory items...
 
 Also, a bit of:
 

--- a/grid_elements/characters/character.gd
+++ b/grid_elements/characters/character.gd
@@ -96,6 +96,7 @@ func move_tween_to(target_position: Vector2, movement_type: int, invisible_trans
 				ease_type = Tween.EASE_OUT
 
 		var tween = create_mov_tween()
+		tween.set_parallel(true)
 		tween.tween_property(self, "position", snap(target_position), duration).set_trans(transition_type).set_ease(ease_type)
 		if invisible_transition: # we remove the alpha component of the color to make the node transparent and we put it back
 			tween.tween_property(self, "modulate:a", max_alpha, duration).from(0.0).set_trans(transition_type).set_ease(ease_type)

--- a/grid_elements/characters/character.gd
+++ b/grid_elements/characters/character.gd
@@ -174,9 +174,12 @@ func manage_collision(character: Area2D, damage: int, slight_recoil: bool) -> vo
 	apply_damage(damage)
 
 # Workaround because the classic Tween node has been deprecated in Godot 3.5 in favor of SceneTreeTween
+var tween: SceneTreeTween
 func create_mov_tween() -> SceneTreeTween:
 	is_moving = true
-	var tween = create_tween()
+	if tween:
+		tween.kill() # Abort the previous animation to avoid concurrency issues
+	tween = create_tween()
 	tween.connect("finished", self, "on_mov_tween_finished")
 	return tween
 

--- a/grid_elements/characters/character.gd
+++ b/grid_elements/characters/character.gd
@@ -1,6 +1,7 @@
 class_name Character
 extends GridElement
 
+signal mov_tween_finished
 signal health_changed
 signal died
 
@@ -29,6 +30,7 @@ var maze: Maze
 # more than one instance exists at the same time, but we don't want to display @ and numbers in the GUI
 var char_name: String
 var previous_positions = []
+var is_moving = false
 var running_duration: float
 var walking_duration: float
 var collision_duration: float
@@ -92,13 +94,13 @@ func move_tween_to(target_position: Vector2, movement_type: int, invisible_trans
 				duration = collision_duration
 				transition_type = Tween.TRANS_BOUNCE
 				ease_type = Tween.EASE_OUT
-		
-		tween.interpolate_property(self, "position", position, snap(target_position), duration, transition_type, ease_type)
+
+		var tween = create_mov_tween()
+		tween.tween_property(self, "position", snap(target_position), duration).set_trans(transition_type).set_ease(ease_type)
 		if invisible_transition: # we remove the alpha component of the color to make the node transparent and we put it back
-			tween.interpolate_property(self, "modulate:a", 0.0, max_alpha, duration, transition_type, ease_type)
-		
+			tween.tween_property(self, "modulate:a", max_alpha, duration).from(0.0).set_trans(transition_type).set_ease(ease_type)
+
 		append_to_previous_positions(position)
-		tween.start()
 		return true
 
 func move_tween_if_possible_to(target_cell: Vector2, movement_type: int, invisible_transition: bool = false) -> bool:
@@ -116,13 +118,13 @@ func dash_to(target_cell: Vector2) -> void:
 			audio_player.stream = Utils.get_random_elem([DASH_01_SOUND, DASH_02_SOUND])
 			audio_player.play()
 			break
-	yield(tween, "tween_all_completed")
+	yield(self, "mov_tween_finished")
 	phasing = false
 
 func teleport_to(target_position: Vector2) -> void:
 	phasing = true
 	move_tween_to(target_position, MovementType.RUN, true)
-	yield(tween, "tween_all_completed")
+	yield(self, "mov_tween_finished")
 	phasing = false
 
 func increase_health_if_possible(increment: int) -> bool:
@@ -141,14 +143,13 @@ func teleport_while_healing_to(target_position: Vector2) -> void:
 	increase_health_if_possible(Utils.rounded_half(max_health))
 
 func bounce_tween(dir: Vector2) -> void: # two pixels
-	tween.interpolate_property(self, "position", position + 2 * dir, snap(position), bounce_duration, Tween.TRANS_BOUNCE, Tween.EASE_OUT)
-	tween.start()
+  create_mov_tween().tween_property(self, "position", snap(position), bounce_duration).from(position + 2 * dir).set_trans(Tween.TRANS_BOUNCE).set_ease(Tween.EASE_OUT)
 
 func collide(dir: Vector2, slight_recoil: bool) -> void:
 	ongoing_collision = true
 	if slight_recoil or !move_tween_if_possible_to(dir * Maze.TILE_SIZE, MovementType.COLLISION):
 		bounce_tween(dir)
-	yield(tween, "tween_all_completed")
+	yield(self, "mov_tween_finished")
 	ongoing_collision = false
 
 func apply_damage(damage: int) -> void:
@@ -171,3 +172,14 @@ func manage_collision(character: Area2D, damage: int, slight_recoil: bool) -> vo
 		else:
 			collide(Vector2.DOWN, slight_recoil)
 	apply_damage(damage)
+
+# Workaround because the classic Tween node has been deprecated in Godot 3.5 in favor of SceneTreeTween
+func create_mov_tween() -> SceneTreeTween:
+	is_moving = true
+	var tween = create_tween()
+	tween.connect("finished", self, "on_mov_tween_finished")
+	return tween
+
+func on_mov_tween_finished() -> void:
+	is_moving = false
+	emit_signal("mov_tween_finished", self)

--- a/grid_elements/characters/character.gd
+++ b/grid_elements/characters/character.gd
@@ -174,14 +174,18 @@ func manage_collision(character: Area2D, damage: int, slight_recoil: bool) -> vo
 	apply_damage(damage)
 
 # Workaround because the classic Tween node has been deprecated in Godot 3.5 in favor of SceneTreeTween
-var tween: SceneTreeTween
+var mov_tween: SceneTreeTween
 func create_mov_tween() -> SceneTreeTween:
+	kill_mov_tween()
 	is_moving = true
-	if tween:
-		tween.kill() # Abort the previous animation to avoid concurrency issues
-	tween = create_tween()
-	tween.connect("finished", self, "on_mov_tween_finished")
-	return tween
+	mov_tween = create_tween()
+	mov_tween.connect("finished", self, "on_mov_tween_finished")
+	return mov_tween
+
+func kill_mov_tween() -> void:
+	if mov_tween:
+		mov_tween.kill() # Abort the previous animation to avoid concurrency issues
+		is_moving = false
 
 func on_mov_tween_finished() -> void:
 	is_moving = false

--- a/grid_elements/characters/non_player/allies/ally.gd
+++ b/grid_elements/characters/non_player/allies/ally.gd
@@ -20,7 +20,7 @@ func _ready() -> void:
 func _process(_delta):
 	if !knows_player and player_is_visible():
 		knows_player = true
-	if !tween.is_active() and knows_player:
+	if !is_moving and knows_player:
 		var path = get_point_path_to(player.position)
 		if path.size() > teleport_threshold: # to follow the player while dashing
 			teleport_to(player.position)

--- a/grid_elements/characters/non_player/enemies/corporeal_enemies/mobile_enemies/mobile_enemy.gd
+++ b/grid_elements/characters/non_player/enemies/corporeal_enemies/mobile_enemies/mobile_enemy.gd
@@ -7,3 +7,5 @@ const IS_IMMOBILE = false
 func _init(initial_position: Vector2, player, maze: Maze, main: Node, texture: Texture, name: String, vision: int, hearing: int, min_time_between_walks: float, max_walk_length: int, speed: float, initial_health: int, atk: int, slashing_def: int, blunt_def: int) \
 .(initial_position, player, maze, main, texture, name, vision, hearing, min_time_between_walks, max_walk_length, speed, initial_health, atk, slashing_def, blunt_def, FRIENDLY_FIRE, IS_IMMOBILE) -> void:
 	pass
+
+# TODO: Add minotaur, maybe at level 5 (50% chance it will appear instead of another enemy). This will be release 1.0.5, and will not need debug. Delete 1.0.2 and 1.0.3

--- a/grid_elements/characters/non_player/enemies/corporeal_enemies/mobile_enemies/mobile_enemy.gd
+++ b/grid_elements/characters/non_player/enemies/corporeal_enemies/mobile_enemies/mobile_enemy.gd
@@ -7,5 +7,3 @@ const IS_IMMOBILE = false
 func _init(initial_position: Vector2, player, maze: Maze, main: Node, texture: Texture, name: String, vision: int, hearing: int, min_time_between_walks: float, max_walk_length: int, speed: float, initial_health: int, atk: int, slashing_def: int, blunt_def: int) \
 .(initial_position, player, maze, main, texture, name, vision, hearing, min_time_between_walks, max_walk_length, speed, initial_health, atk, slashing_def, blunt_def, FRIENDLY_FIRE, IS_IMMOBILE) -> void:
 	pass
-
-# TODO: Add minotaur, maybe at level 5 (50% chance it will appear instead of another enemy). This will be release 1.0.5, and will not need debug. Delete 1.0.2 and 1.0.3

--- a/grid_elements/characters/non_player/enemies/corporeal_enemies/mobile_enemies/spider/spider.gd
+++ b/grid_elements/characters/non_player/enemies/corporeal_enemies/mobile_enemies/spider/spider.gd
@@ -19,5 +19,5 @@ func _init(initial_position: Vector2, player, maze: Maze, main: Node) \
 	pass
 
 func collision_received(sender: String, collider_position: Vector2) -> void:
-	if !tween.is_active() and (sender == WEB_NAME):
+	if !is_moving and sender == WEB_NAME:
 		hunt(get_point_path_to(collider_position))

--- a/grid_elements/characters/non_player/enemies/enemy.gd
+++ b/grid_elements/characters/non_player/enemies/enemy.gd
@@ -60,7 +60,7 @@ func hunt(path: PoolVector2Array) -> void:
 	follow_path(path, MovementType.RUN, path.size())
 
 func _process(_delta) -> void:
-	if !tween.is_active(): # if the enemy is already doing something, we skip to try again in the next frame. Another solution? Probably with a bool
+	if !is_moving: # if the enemy is already doing something, we skip to try again in the next frame. Another solution? Probably with a bool
 		# TODO: Check distances before calling get_point_path_to?
 		var path = get_point_path_to(player.position)
 		if player_is_visible():
@@ -83,14 +83,14 @@ func choose_walk_length() -> int:
 		return max_walk_length
 
 func on_movement_timer_timeout() -> void:
-	if !tween.is_active():
+	if !is_moving:
 		if Utils.fifty_percent_chance(): # to make the mob more unpredictable, we don't want it to move with every timeout
 			follow_path(get_point_path_to(maze.random_position()), MovementType.WALK, choose_walk_length()) # random walk
 		elif Utils.fifty_percent_chance():
 			special_movement()
 
 func run_to_explosion_if_audible(target: Vector2) -> void:
-	if !tween.is_active():
+	if !is_moving:
 		var path = get_point_path_to(target)
 		if path.size() <= hearing_loud_sounds:
 			follow_path(path, MovementType.RUN, path.size())

--- a/grid_elements/characters/non_player/enemies/incorporeal_enemies/incorporeal_enemy.gd
+++ b/grid_elements/characters/non_player/enemies/incorporeal_enemies/incorporeal_enemy.gd
@@ -16,5 +16,5 @@ func walk_through_walls(dir: Vector2, maximum_path_length: int) -> void:
 		if player_is_visible():
 			break
 		move_tween_to(target, MovementType.WALK, true)
-		yield(tween, "tween_all_completed")
+		yield(self, "mov_tween_finished")
 	phasing = false

--- a/grid_elements/characters/non_player/enemies/incorporeal_enemies/shadow_clone/shadow_clone.gd
+++ b/grid_elements/characters/non_player/enemies/incorporeal_enemies/shadow_clone/shadow_clone.gd
@@ -24,5 +24,5 @@ func special_movement() -> void:
 
 func player_found(sender: String) -> void:
 	# The Shadow and its clones are supposed to have a shared vision (but only the clones attack mindlessly when called)
-	if !tween.is_active() and (sender == SHADOW_NAME or sender == CLONE_NAME):
+	if !is_moving and (sender == SHADOW_NAME or sender == CLONE_NAME):
 		hunt(get_point_path_to(player.position))

--- a/grid_elements/characters/non_player/non_player.gd
+++ b/grid_elements/characters/non_player/non_player.gd
@@ -59,6 +59,6 @@ func follow_path(path: PoolVector2Array, movement_type: int, maximum_path_length
 		if ongoing_collision or (stop_before_obstacles and obstacle_is_ahead(point)):
 			break
 		move_tween_to(point, movement_type)
-		yield(tween, "tween_all_completed")
+		yield(self, "mov_tween_finished")
 		if advance_while_searching_player and player_is_visible():
 			break # we exit the loop to allow the method consumer to decide what to do (e.g. update the path)

--- a/grid_elements/characters/player/player.gd
+++ b/grid_elements/characters/player/player.gd
@@ -52,11 +52,13 @@ func _process(_delta) -> void:
 					move_tween_to(position + target_cell, MovementType.RUN)
 				else:
 					move_tween_if_possible_to(target_cell, MovementType.RUN)
-			elif teleport_ability and Input.is_action_pressed("teleport"):
-				emit_signal("teleport_requested")
-			elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped():
-				emit_signal("bomb_requested")
-				bomb_timer.start(BOMB_TIMER_DURATION)
+
+func _unhandled_input(_event) -> void:
+	if teleport_ability and Input.is_action_pressed("teleport"):
+		emit_signal("teleport_requested")
+	elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped():
+		emit_signal("bomb_requested")
+		bomb_timer.start(BOMB_TIMER_DURATION)
 
 func change_transparency(new_max_alpha: float) -> void:
 	max_alpha = new_max_alpha

--- a/grid_elements/characters/player/player.gd
+++ b/grid_elements/characters/player/player.gd
@@ -56,7 +56,7 @@ func _process(_delta) -> void:
 func _unhandled_input(_event) -> void:
 	if teleport_ability and Input.is_action_pressed("teleport"):
 		emit_signal("teleport_requested")
-	elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped():
+	elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped() and !tween.is_active(): # We require the player to be stationary to prevent bombs from being placed between two tiles
 		emit_signal("bomb_requested")
 		bomb_timer.start(BOMB_TIMER_DURATION)
 

--- a/grid_elements/characters/player/player.gd
+++ b/grid_elements/characters/player/player.gd
@@ -43,7 +43,7 @@ func _ready() -> void:
 
 func _process(_delta) -> void:
 	for dir_key in MOTION_INPUTS.keys():
-		if !tween.is_active(): # we check this 4 times per frame to improve the responsiveness in the corners
+		if !is_moving: # we check this 4 times per frame to improve the responsiveness in the corners
 			if Input.is_action_pressed(dir_key):
 				var target_cell = MOTION_INPUTS[dir_key] * Maze.TILE_SIZE
 				if dash_ability and Input.is_action_pressed("dash"):
@@ -56,7 +56,7 @@ func _process(_delta) -> void:
 func _unhandled_input(_event) -> void:
 	if teleport_ability and Input.is_action_pressed("teleport"):
 		emit_signal("teleport_requested")
-	elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped() and !tween.is_active(): # We require the player to be stationary to prevent bombs from being placed between tiles
+	elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped() and !is_moving: # We require the player to be stationary to prevent bombs from being placed between tiles
 		emit_signal("bomb_requested")
 		bomb_timer.start(BOMB_TIMER_DURATION)
 

--- a/grid_elements/characters/player/player.gd
+++ b/grid_elements/characters/player/player.gd
@@ -56,7 +56,7 @@ func _process(_delta) -> void:
 func _unhandled_input(_event) -> void:
 	if teleport_ability and Input.is_action_pressed("teleport"):
 		emit_signal("teleport_requested")
-	elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped() and !tween.is_active(): # We require the player to be stationary to prevent bombs from being placed between two tiles
+	elif bomb_ability and Input.is_action_pressed("bomb") and bomb_timer.is_stopped() and !tween.is_active(): # We require the player to be stationary to prevent bombs from being placed between tiles
 		emit_signal("bomb_requested")
 		bomb_timer.start(BOMB_TIMER_DURATION)
 

--- a/grid_elements/grid_element.gd
+++ b/grid_elements/grid_element.gd
@@ -19,7 +19,6 @@ var main: Node
 var texture: Texture
 var sprite: Sprite
 var collision_shape: CollisionShape2D
-var tween: Tween
 var ray: RayCast2D
 var audio_player: AudioStreamPlayer2D
 var light: Light2D
@@ -35,22 +34,19 @@ func _ready() -> void:
 	sprite = Sprite.new()
 	sprite.texture = texture
 	add_child(sprite)
-	
+
 	var rectangle_shape = RectangleShape2D.new()
 	rectangle_shape.extents = Vector2(7.50361, 7.37397)
 	collision_shape = CollisionShape2D.new()
 	collision_shape.shape = rectangle_shape
 	add_child(collision_shape)
-	
-	tween = Tween.new()
-	add_child(tween)
-	
+
 	ray = RayCast2D.new()
 	add_child(ray)
-	
+
 	audio_player = AudioStreamPlayer2D.new()
 	add_child(audio_player)
-	
+
 	light = Light2D.new()
 	light.texture = LIGHT_TEXTURE
 	light.mode = Light2D.MODE_MIX
@@ -88,6 +84,6 @@ func enable() -> void:
 
 func fade() -> void:
 	disable()
-	tween.interpolate_property(self, "scale", scale, Vector2(2.0, 2.0), 0.1)
-	tween.interpolate_property(self, "modulate:a", modulate.a, 0, 0.1)
-	tween.start()
+	var tween = create_tween()
+	tween.tween_property(self, "scale", Vector2(2.0, 2.0), 0.1)
+	tween.tween_property(self, "modulate:a", 0, 0.1)

--- a/grid_elements/grid_element.gd
+++ b/grid_elements/grid_element.gd
@@ -82,8 +82,10 @@ func enable() -> void:
 	collision_shape.set_deferred("disabled", false)
 	set_process(true)
 
-func fade() -> void:
+func fade() -> SceneTreeTween:
 	disable()
 	var tween = create_tween()
+	tween.set_parallel(true)
 	tween.tween_property(self, "scale", Vector2(2.0, 2.0), 0.1)
 	tween.tween_property(self, "modulate:a", 0, 0.1)
+	return tween

--- a/grid_elements/things/event/event.gd
+++ b/grid_elements/things/event/event.gd
@@ -13,14 +13,11 @@ func _init(position: Vector2, main: Node).(position, main, TEXTURE) -> void:
 func _ready() -> void:
 	pause_mode = PAUSE_MODE_PROCESS
 	audio_player.stream = SOUND
-	
+
 	connect("area_entered", main, "on_event_area_entered", [self])
-	tween.connect("tween_all_completed", self, "on_tween_all_completed")
-	reverse_transparency()
+	start_blinking()
 
-func reverse_transparency() -> void:
-	tween.interpolate_property(self, "modulate:a", modulate.a, max_alpha - modulate.a, 1.0)
-	tween.start()
-
-func on_tween_all_completed() -> void:
-	reverse_transparency()
+func start_blinking() -> void:
+	var tween = create_tween()
+	tween.tween_property(self, "modulate:a", max_alpha - modulate.a, 1.0)
+	tween.tween_callback(self, "start_blinking")

--- a/gui_elements/custom_theme.gd
+++ b/gui_elements/custom_theme.gd
@@ -32,3 +32,7 @@ func _init(custom_font: CustomFont, background_color: Color) -> void:
 	set_stylebox("normal", "Button", style_box)
 	set_stylebox("hover", "Button", style_box_inverted)
 	set_stylebox("pressed", "Button", style_box_inverted)
+
+	# 3.4.4:
+	# set_color("font_color_focus", "Button", font_color.inverted())
+	# set_stylebox("focus", "Button", style_box_inverted)

--- a/gui_elements/custom_theme.gd
+++ b/gui_elements/custom_theme.gd
@@ -23,16 +23,12 @@ func _init(custom_font: CustomFont, background_color: Color) -> void:
 	
 	var style_box_inverted = style_box.duplicate()
 	style_box_inverted.bg_color = style_box.bg_color.inverted()
-	style_box_inverted.border_color = style_box.border_color
+	# style_box_inverted.border_color = style_box.border_color
 	
 	set_font("font", "Button", custom_font)
 	set_color("font_color", "Button", font_color)
-	set_color("font_color_hover", "Button", font_color.inverted())
+	set_color("font_color_focus", "Button", font_color.inverted())
 	set_color("font_color_pressed", "Button", font_color.inverted())
 	set_stylebox("normal", "Button", style_box)
-	set_stylebox("hover", "Button", style_box_inverted)
+	set_stylebox("focus", "Button", style_box_inverted)
 	set_stylebox("pressed", "Button", style_box_inverted)
-
-	# 3.4.4:
-	# set_color("font_color_focus", "Button", font_color.inverted())
-	# set_stylebox("focus", "Button", style_box_inverted)

--- a/gui_elements/popup/event_popup.gd
+++ b/gui_elements/popup/event_popup.gd
@@ -131,11 +131,11 @@ func _ready() -> void:
 	message.text = full_message
 	message.theme = small_font_theme
 	
-	yes_button = Button.new()
+	yes_button = PopupButton.new()
 	yes_button.text = "yes"
 	yes_button.theme = normal_font_theme
 	
-	no_button = Button.new()
+	no_button = PopupButton.new()
 	no_button.text = "no"
 	no_button.theme = normal_font_theme
 	

--- a/gui_elements/popup/event_popup.gd
+++ b/gui_elements/popup/event_popup.gd
@@ -131,11 +131,11 @@ func _ready() -> void:
 	message.text = full_message
 	message.theme = small_font_theme
 	
-	yes_button = PopupButton.new()
+	yes_button = Button.new()
 	yes_button.text = "yes"
 	yes_button.theme = normal_font_theme
 	
-	no_button = PopupButton.new()
+	no_button = Button.new()
 	no_button.text = "no"
 	no_button.theme = normal_font_theme
 	

--- a/gui_elements/popup/menu_popup.gd
+++ b/gui_elements/popup/menu_popup.gd
@@ -77,7 +77,7 @@ func get_keybinds(input_event_action_name: String) -> String:
 	var keybinds = []
 	for input_event in InputMap.get_action_list(input_event_action_name):
 		if input_event is InputEventKey:
-			keybinds.append(input_event.as_text())
+			keybinds.append(input_event.as_text()) # Bug for physical keys here (3.4.4), already fixed in 3.x
 		elif input_event is InputEventJoypadButton:
 			keybinds.append(Input.get_joy_button_string(input_event.button_index))
 	return PoolStringArray(keybinds).join(", ")

--- a/gui_elements/popup/menu_popup.gd
+++ b/gui_elements/popup/menu_popup.gd
@@ -77,7 +77,7 @@ func get_keybinds(input_event_action_name: String) -> String:
 	var keybinds = []
 	for input_event in InputMap.get_action_list(input_event_action_name):
 		if input_event is InputEventKey:
-			keybinds.append(input_event.as_text()) # Bug for physical keys here (3.4.4), fixed in 3.5
+			keybinds.append(input_event.as_text())
 		elif input_event is InputEventJoypadButton:
 			keybinds.append(Input.get_joy_button_string(input_event.button_index))
 	return PoolStringArray(keybinds).join(", ")

--- a/gui_elements/popup/menu_popup.gd
+++ b/gui_elements/popup/menu_popup.gd
@@ -73,13 +73,34 @@ func on_exit_button_pressed() -> void:
 func on_continue_button_pressed() -> void:
 	 hide_and_reset_buttons()
 
+func input_event_to_string(input_event: InputEvent) -> String:
+	if input_event is InputEventJoypadButton:
+		return Input.get_joy_button_string(input_event.button_index)
+	elif input_event is InputEventJoypadMotion:
+		return joy_motion_to_string(input_event.axis, input_event.axis_value)
+	else:
+		return input_event.as_text()
+
+func joy_motion_to_string(axis: int, value: float) -> String:
+	match axis:
+		JOY_AXIS_0:
+			if value > 0:
+				return "Joystick Right"
+			else:
+				return "Joystick Left"
+		JOY_AXIS_1:
+			if value > 0:
+				return "Joystick Down"
+			else:
+				return "Joystick Up"
+		_:
+			return "Unsupported Axis" # In this game we'll only use the left stick
+
 func get_keybinds(input_event_action_name: String) -> String:
+	var input_events = InputMap.get_action_list(input_event_action_name)
 	var keybinds = []
-	for input_event in InputMap.get_action_list(input_event_action_name):
-		if input_event is InputEventKey:
-			keybinds.append(input_event.as_text())
-		elif input_event is InputEventJoypadButton:
-			keybinds.append(Input.get_joy_button_string(input_event.button_index))
+	for ev in input_events:
+		keybinds.append(input_event_to_string(ev))
 	return PoolStringArray(keybinds).join(", ")
 
 func add_keybind(keybind_desc: String, input_event_action_name: String) -> void:

--- a/gui_elements/popup/menu_popup.gd
+++ b/gui_elements/popup/menu_popup.gd
@@ -38,7 +38,7 @@ func _ready() -> void:
 	add_keybind("LEFT", "ui_left")
 	add_keybind("DASH (requires boots)", "dash")
 	add_keybind("TELEPORT TO START (requires amulet)", "teleport")
-	add_keybind("ACCEPT / BOMB (requires bomb bag)", "ui_accept")
+	add_keybind("ACCEPT / BOMB (requires bomb bag, not moving)", "ui_accept")
 	add_child(keybinds_container)
 	keybinds_container.set_anchors_and_margins_preset(Control.PRESET_BOTTOM_RIGHT, 0, MIN_MARGIN)
 	

--- a/gui_elements/popup/menu_popup.gd
+++ b/gui_elements/popup/menu_popup.gd
@@ -17,11 +17,11 @@ func _ready() -> void:
 	message.text = GAME_NAME
 	message.theme = large_font_theme
 	
-	new_game_button = PopupButton.new()
+	new_game_button = Button.new()
 	new_game_button.text = "new game"
 	new_game_button.theme = normal_font_theme
 	
-	exit_button = PopupButton.new()
+	exit_button = Button.new()
 	exit_button.text = "exit"
 	exit_button.theme = normal_font_theme
 	

--- a/gui_elements/popup/menu_popup.gd
+++ b/gui_elements/popup/menu_popup.gd
@@ -17,11 +17,11 @@ func _ready() -> void:
 	message.text = GAME_NAME
 	message.theme = large_font_theme
 	
-	new_game_button = Button.new()
+	new_game_button = PopupButton.new()
 	new_game_button.text = "new game"
 	new_game_button.theme = normal_font_theme
 	
-	exit_button = Button.new()
+	exit_button = PopupButton.new()
 	exit_button.text = "exit"
 	exit_button.theme = normal_font_theme
 	
@@ -77,7 +77,7 @@ func get_keybinds(input_event_action_name: String) -> String:
 	var keybinds = []
 	for input_event in InputMap.get_action_list(input_event_action_name):
 		if input_event is InputEventKey:
-			keybinds.append(input_event.as_text()) # Bug for physical keys here (3.4.4), already fixed in 3.x
+			keybinds.append(input_event.as_text()) # Bug for physical keys here (3.4.4), fixed in 3.5
 		elif input_event is InputEventJoypadButton:
 			keybinds.append(Input.get_joy_button_string(input_event.button_index))
 	return PoolStringArray(keybinds).join(", ")

--- a/gui_elements/popup/menu_popup.gd
+++ b/gui_elements/popup/menu_popup.gd
@@ -32,13 +32,13 @@ func _ready() -> void:
 	continue_button.hide()
 	
 	keybinds_container = VBoxContainer.new()
-	add_keybind("UP", "ui_up")
-	add_keybind("DOWN", "ui_down")
-	add_keybind("RIGHT", "ui_right")
-	add_keybind("LEFT", "ui_left")
+	# add_keybind("UP", "ui_up") too obvious!
+	# add_keybind("DOWN", "ui_down")
+	# add_keybind("RIGHT", "ui_right")
+	# add_keybind("LEFT", "ui_left")
 	add_keybind("DASH (requires boots)", "dash")
 	add_keybind("TELEPORT TO START (requires amulet)", "teleport")
-	add_keybind("ACCEPT / BOMB (requires bomb bag, not moving)", "ui_accept")
+	add_keybind("PLACE BOMB (requires bomb bag & no movement)", "ui_accept")
 	add_child(keybinds_container)
 	keybinds_container.set_anchors_and_margins_preset(Control.PRESET_BOTTOM_RIGHT, 0, MIN_MARGIN)
 	

--- a/gui_elements/popup/popup_button.gd
+++ b/gui_elements/popup/popup_button.gd
@@ -1,7 +1,0 @@
-class_name PopupButton
-extends Button
-
-func _init() -> void:
-	# To avoid confusing in the UI the button that has the focus with the button highlighted by the mouse.
-	# This will also force us to design a game behaving exactly the same way when playing with a PC and when playing with a controller
-	mouse_filter = Control.MOUSE_FILTER_IGNORE 

--- a/gui_elements/popup/popup_button.gd
+++ b/gui_elements/popup/popup_button.gd
@@ -1,0 +1,7 @@
+class_name PopupButton
+extends Button
+
+func _init() -> void:
+	# To avoid confusing in the UI the button that has the focus with the button highlighted by the mouse.
+	# This will also force us to design a game behaving exactly the same way when playing with a PC and when playing with a controller
+	mouse_filter = Control.MOUSE_FILTER_IGNORE 

--- a/gui_elements/popup/popup_ext.gd
+++ b/gui_elements/popup/popup_ext.gd
@@ -36,7 +36,7 @@ func _ready() -> void:
 	v_container = VBoxContainer.new()
 	add_child(v_container)
 	
-	continue_button = Button.new()
+	continue_button = PopupButton.new()
 	continue_button.text = "continue"
 	continue_button.focus_mode = FOCUS_ALL
 	continue_button.theme = normal_font_theme

--- a/gui_elements/popup/popup_ext.gd
+++ b/gui_elements/popup/popup_ext.gd
@@ -36,7 +36,7 @@ func _ready() -> void:
 	v_container = VBoxContainer.new()
 	add_child(v_container)
 	
-	continue_button = PopupButton.new()
+	continue_button = Button.new()
 	continue_button.text = "continue"
 	continue_button.focus_mode = FOCUS_ALL
 	continue_button.theme = normal_font_theme

--- a/main/main.gd
+++ b/main/main.gd
@@ -299,6 +299,7 @@ func clean(everything: bool = false) -> void:
 	remove(maze)
 
 func set_char_position(character: Character, position: Vector2) -> void:
+	character.kill_mov_tween()
 	character.modulate.a = character.max_alpha
 	character.position = position
 

--- a/main/main.gd
+++ b/main/main.gd
@@ -74,6 +74,11 @@ var second_events: Array
 var third_events: Array
 var fourth_events: Array
 
+func _input(_event):
+	if Input.is_action_just_pressed("toggle_fullscreen"):
+		OS.window_fullscreen = !OS.window_fullscreen
+		get_tree().set_input_as_handled() # To prevent Alt + Enter from also executing the actions associated to Enter
+
 func _ready() -> void:
 	randomize()
 #	seed(255) # for testing

--- a/main/main.gd
+++ b/main/main.gd
@@ -44,7 +44,6 @@ var canvas_modulate: CanvasModulate
 var mouse_blocker: MouseBlocker
 var gui_layer: CanvasLayer
 var menu_popup: MenuPopup
-var tween: Tween
 var audio_player: AudioStreamPlayer
 var player: Player
 var player_status_bar: StatusBar
@@ -95,9 +94,6 @@ func _ready() -> void:
 	gui_layer.add_child(menu_popup)
 	menu_popup.popup_centered()
 	
-	tween = Tween.new()
-	add_child(tween)
-	
 	audio_player = AudioStreamPlayer.new()
 	add_child(audio_player)
 	play_track(MAIN_MENU_TRACK)
@@ -139,14 +135,15 @@ func play_track(track: AudioStream, volume: float = 0) -> void:
 	audio_player.volume_db = volume
 	audio_player.play()
 
-func change_volume(target_volume: float, duration: float) -> void:
-	tween.interpolate_property(audio_player, "volume_db", audio_player.volume_db, target_volume, duration)
-	tween.start()
+func change_volume(target_volume: float, duration: float) -> SceneTreeTween:
+	var tween = create_tween()
+	tween.tween_property(audio_player, "volume_db", target_volume, duration)
+	return tween
 
 func change_track(new_track: AudioStream, duration = 0.5) -> void:
 	if audio_player.playing:
-		change_volume(NO_SOUND_VOLUME, duration)
-		yield(tween, "tween_all_completed")
+		var tween = change_volume(NO_SOUND_VOLUME, duration)
+		yield(tween, "finished")
 	play_track(new_track, MUSIC_VOLUME)
 
 func on_audio_player_finished() -> void:
@@ -302,7 +299,6 @@ func clean(everything: bool = false) -> void:
 	remove(maze)
 
 func set_char_position(character: Character, position: Vector2) -> void:
-	character.tween.remove_all()
 	character.modulate.a = character.max_alpha
 	character.position = position
 
@@ -426,7 +422,7 @@ func on_player_teleport_requested() -> void:
 		for ally in allies:
 			if ally.knows_player:
 				ally.teleport_to(STARTING_POSITION)
-				yield(ally.tween, "tween_all_completed")
+				yield(ally, "mov_tween_finished")
 				ally.stand_behind()
 
 func on_player_bomb_requested() -> void:
@@ -469,7 +465,7 @@ func on_character_died(character: Character) -> void:
 			character.double_respawn_time()
 	else:
 		character.fade()
-		yield(character.tween, "tween_all_completed")
+		yield(character, "mov_tween_finished")
 		remove(_get_enemy_status_bar(character))
 		remove(character)
 

--- a/main/main.gd
+++ b/main/main.gd
@@ -41,6 +41,7 @@ const GAME_OVER_TRACK_PATH = ResourcePath.MAIN + "game_over.wav"
 const GAME_OVER_TRACK = preload(GAME_OVER_TRACK_PATH)
 
 var canvas_modulate: CanvasModulate
+var mouse_blocker: MouseBlocker
 var gui_layer: CanvasLayer
 var menu_popup: MenuPopup
 var tween: Tween
@@ -74,11 +75,6 @@ var second_events: Array
 var third_events: Array
 var fourth_events: Array
 
-func _input(_event):
-	if Input.is_action_just_pressed("toggle_fullscreen"):
-		OS.window_fullscreen = !OS.window_fullscreen
-		get_tree().set_input_as_handled() # To prevent the "Enter" of the "Alt + Enter" combo from triggering the "pressed" signal on UI buttons
-
 func _ready() -> void:
 	randomize()
 #	seed(255) # for testing
@@ -88,6 +84,9 @@ func _ready() -> void:
 	
 	canvas_modulate = CanvasModulate.new()
 	add_child(canvas_modulate)
+	
+	mouse_blocker = MouseBlocker.new()
+	add_child(mouse_blocker)
 	
 	gui_layer = CanvasLayer.new()
 	add_child(gui_layer)

--- a/main/main.gd
+++ b/main/main.gd
@@ -465,8 +465,8 @@ func on_character_died(character: Character) -> void:
 			character.enable()
 			character.double_respawn_time()
 	else:
-		character.fade()
-		yield(character, "mov_tween_finished")
+		var tween = character.fade()
+		yield(tween, "finished")
 		remove(_get_enemy_status_bar(character))
 		remove(character)
 

--- a/main/main.gd
+++ b/main/main.gd
@@ -77,7 +77,7 @@ var fourth_events: Array
 func _input(_event):
 	if Input.is_action_just_pressed("toggle_fullscreen"):
 		OS.window_fullscreen = !OS.window_fullscreen
-		get_tree().set_input_as_handled() # To prevent Alt + Enter from also executing the actions associated to Enter
+		get_tree().set_input_as_handled() # To prevent the "Enter" of the "Alt + Enter" combo from triggering the "pressed" signal on UI buttons
 
 func _ready() -> void:
 	randomize()

--- a/main/mouse_blocker.gd
+++ b/main/mouse_blocker.gd
@@ -1,0 +1,20 @@
+class_name MouseBlocker 
+extends Node
+
+# The purpose of this class is to ignore the user's mouse. 
+# This will force us to design a game behaving exactly the same way when playing with a PC and when playing with a controller.
+# Additionally, not having to worry about the mouse saves us the headache of figuring out how to avoid the confusion between focused and hovered UI buttons.
+
+# For convenience, this node also handles fullscreen mode, where we don’t want the cursor to be visible.
+
+func _init():
+	Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
+	set_pause_mode(PAUSE_MODE_PROCESS) # Allow input processing of this node even when the game is paused (so mouse actions keep being ignored)
+
+func _input(event):
+	if event is InputEventMouse:
+		get_tree().set_input_as_handled() # So we do nothing except prevent the event from propagating
+
+	if Input.is_action_just_pressed("toggle_fullscreen"):
+		OS.window_fullscreen = !OS.window_fullscreen
+		get_tree().set_input_as_handled() # To prevent the "Enter" of the "Alt + Enter" combo from triggering the "pressed" signal on UI buttons

--- a/project.godot
+++ b/project.godot
@@ -254,6 +254,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://grid_elements/characters/player/player.gd"
 }, {
+"base": "Button",
+"class": "PopupButton",
+"language": "GDScript",
+"path": "res://gui_elements/popup/popup_button.gd"
+}, {
 "base": "Popup",
 "class": "PopupExt",
 "language": "GDScript",
@@ -404,6 +409,7 @@ _global_script_class_icons={
 "MonsterGhost": "",
 "NonPlayer": "",
 "Player": "",
+"PopupButton": "",
 "PopupExt": "",
 "RecursiveBacktracker": "",
 "RecursiveDivision": "",
@@ -436,7 +442,6 @@ config/windows_native_icon="res://icon.ico"
 
 gdscript/warnings/shadowed_variable=false
 gdscript/warnings/unused_class_variable=true
-gdscript/warnings/return_value_discarded=false
 gdscript/warnings/unsafe_cast=true
 gdscript/warnings/unsafe_call_argument=true
 
@@ -449,71 +454,71 @@ window/stretch/aspect="keep"
 
 ui_accept={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":1,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 ui_cancel={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 ui_left={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":81,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":81,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 ui_right={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 ui_up={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 ui_down={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 dash={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 teleport={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777220,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777220,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":3,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 bomb={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":1,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 menu={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":10,"pressure":0.0,"pressed":false,"script":null)
  ]

--- a/project.godot
+++ b/project.godot
@@ -469,8 +469,7 @@ ui_cancel={
 ui_left={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":81,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":65,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
@@ -484,8 +483,7 @@ ui_right={
 ui_up={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":87,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
@@ -521,6 +519,11 @@ menu={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":10,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+toggle_fullscreen={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 

--- a/project.godot
+++ b/project.godot
@@ -471,6 +471,7 @@ ui_left={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":65,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
@@ -478,6 +479,7 @@ ui_right={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
@@ -485,6 +487,7 @@ ui_up={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":87,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
@@ -492,6 +495,7 @@ ui_down={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
  ]
 }

--- a/project.godot
+++ b/project.godot
@@ -244,6 +244,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://grid_elements/characters/non_player/enemies/incorporeal_enemies/monster_ghost/monster_ghost.gd"
 }, {
+"base": "Node",
+"class": "MouseBlocker",
+"language": "GDScript",
+"path": "res://main/mouse_blocker.gd"
+}, {
 "base": "Character",
 "class": "NonPlayer",
 "language": "GDScript",
@@ -253,11 +258,6 @@ _global_script_classes=[ {
 "class": "Player",
 "language": "GDScript",
 "path": "res://grid_elements/characters/player/player.gd"
-}, {
-"base": "Button",
-"class": "PopupButton",
-"language": "GDScript",
-"path": "res://gui_elements/popup/popup_button.gd"
 }, {
 "base": "Popup",
 "class": "PopupExt",
@@ -407,9 +407,9 @@ _global_script_class_icons={
 "MenuPopup": "",
 "MobileEnemy": "",
 "MonsterGhost": "",
+"MouseBlocker": "",
 "NonPlayer": "",
 "Player": "",
-"PopupButton": "",
 "PopupExt": "",
 "RecursiveBacktracker": "",
 "RecursiveDivision": "",

--- a/project.godot
+++ b/project.godot
@@ -440,6 +440,7 @@ config/windows_native_icon="res://icon.ico"
 
 [debug]
 
+settings/fps/force_fps=60
 gdscript/warnings/shadowed_variable=false
 gdscript/warnings/unused_class_variable=true
 gdscript/warnings/unsafe_cast=true


### PR DESCRIPTION
- Godot 3.6 compatible.
- Physical keys.
- Fullscreen mode.
- Tween node replaced by SceneTreeTween to prepare for Godot 4 transition.